### PR TITLE
Keep syncing as long as the max number of results is being received

### DIFF
--- a/internal/tmpbbs/postsyncserver.go
+++ b/internal/tmpbbs/postsyncserver.go
@@ -14,7 +14,7 @@ type PostSyncServer struct {
 	postStore *PostStore
 }
 
-const maxMaxResults = 1024
+const maxMaxResults = 500
 
 func NewPostSyncServer(postStore *PostStore) *PostSyncServer {
 	return &PostSyncServer{


### PR DESCRIPTION
Sleep only when all of the peer's posts have been synced.

Reduce max max results to 500 so a full batch of maximum size posts can fit in gRPC's message size limit.