### PR TITLE
Use Round when calculating post age

### DIFF
--- a/internal/tmpbbs/displaypost.go
+++ b/internal/tmpbbs/displaypost.go
@@ -131,7 +131,7 @@ func (dp displayPost) RepliesPage(page int, perPage int) []*displayPost {
 }
 
 func (dp displayPost) TimeAgo() string {
-	age := time.Since(dp.time)
+	age := time.Since(dp.time.Round(0))
 	if age < 1*time.Hour {
 		return dp.Printer.Sprintf("%dm ago", int64(math.Round(age.Minutes())))
 	}


### PR DESCRIPTION
The monotonic clock stops if the computer goes to sleep so the wall clock makes more sense.

See https://pkg.go.dev/time#hdr-Monotonic_Clocks