### PR TITLE
Truncate and round cache start time

### DIFF
--- a/internal/tmpbbs/immutablegethandler.go
+++ b/internal/tmpbbs/immutablegethandler.go
@@ -20,7 +20,7 @@ type immutableGetHandler struct {
 func newImmutableGetHandler(wrappedHandler http.Handler, startTime time.Time) *immutableGetHandler {
 	handler := immutableGetHandler{
 		wrappedHandler: wrappedHandler,
-		startTime:      startTime,
+		startTime:      startTime.Truncate(time.Second).Round(0),
 		lastModified:   startTime.Format(time.RFC1123),
 	}
 	if Commit != "" {


### PR DESCRIPTION
Match the precision of the header and drop monotonic clock.