### PR TITLE
Use end of ULID for empty titles

### DIFF
--- a/internal/tmpbbs/displaypost.go
+++ b/internal/tmpbbs/displaypost.go
@@ -151,7 +151,7 @@ func (dp displayPost) TimeAgo() string {
 }
 
 func (dp displayPost) emptyTitle() string {
-	return fmt.Sprintf("%s-%s", dp.uuid[10:13], dp.uuid[13:17])
+	return fmt.Sprintf("%s-%s", dp.uuid[19:22], dp.uuid[22:26])
 }
 
 func (dp displayPost) expandEmoji(input string, parser parser) string {


### PR DESCRIPTION
To avoid title collisions for posts created close together in time.