### PR TITLE
Crockford base 32 decode IDs in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ the same platform) and the data can be pulled and kept up-to-date using
   * tripcodes in `username#secret` format
   * shareable URL QR codes
   * every instance distributes the software by serving its own binary
+  * post IDs in URLs are error resistant and pronounceable Crockford Base 32
 
 # Installation
 

--- a/internal/tmpbbs/crockforddecode.go
+++ b/internal/tmpbbs/crockforddecode.go
@@ -1,0 +1,15 @@
+package tmpbbs
+
+import "strings"
+
+var crockfordReplacer = strings.NewReplacer( //nolint:gochecknoglobals // constant defined in the spec
+	"-", "",
+	"I", "1",
+	"L", "1",
+	"O", "0",
+	"U", "",
+)
+
+func crockfordDecode(s string) string {
+	return crockfordReplacer.Replace(strings.ToUpper(s))
+}

--- a/internal/tmpbbs/post.go
+++ b/internal/tmpbbs/post.go
@@ -67,7 +67,7 @@ func (p *post) URL() string {
 		return "/"
 	}
 
-	return "/p/" + p.uuid
+	return "/p/" + p.readableID()
 }
 
 // bump moves a post to the top of its parent's replies then bumps each of its
@@ -91,6 +91,11 @@ func (p *post) delete() {
 	p.Title = ""
 	p.Author = ""
 	p.Body = "deleted"
+}
+
+func (p *post) readableID() string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s", p.uuid[:4], p.uuid[4:8], p.uuid[8:12], p.uuid[12:16], p.uuid[16:20],
+		p.uuid[20:24], p.uuid[24:])
 }
 
 func (p *post) repliesPageURL(page int, anchor string) string {

--- a/internal/tmpbbs/postgethandler.go
+++ b/internal/tmpbbs/postgethandler.go
@@ -63,7 +63,7 @@ func (pgh *postGetHandler) ServeHTTP(responseWriter http.ResponseWriter, request
 
 	printer := message.NewPrinter(message.MatchLanguage(request.Header.Get("Accept-Language"), "en-US"))
 
-	if !pgh.postStore.get(request.PathValue("uuid"), func(post *post) {
+	if !pgh.postStore.get(crockfordDecode(request.PathValue("uuid")), func(post *post) {
 		displayPost := newDisplayPost(post, printer, pgh.basicEmojiParser, pgh.wrappingEmojiParser, pgh.markdownParser)
 		if !displayPost.hasRepliesPage(repliesPage, pgh.repliesPerPage) {
 			http.NotFound(responseWriter, request)

--- a/internal/tmpbbs/postposthandler.go
+++ b/internal/tmpbbs/postposthandler.go
@@ -19,7 +19,7 @@ func newPostPostHandler(postStore *PostStore, tripcoder *Tripcoder) *postPostHan
 }
 
 func (pph postPostHandler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
-	parentUUID := cmp.Or(request.PathValue("parentUUID"), pph.postStore.posts[0].uuid)
+	parentUUID := cmp.Or(crockfordDecode(request.PathValue("parentUUID")), pph.postStore.posts[0].uuid)
 	if !pph.postStore.hasPost(parentUUID) {
 		http.NotFound(responseWriter, request)
 


### PR DESCRIPTION
Correct spoken and written errors caused by similar characters.

Make case-insensitive and accept any hyphen scheme.