### PR TITLE
Remove nil check for wep.wrapper

### DIFF
--- a/internal/tmpbbs/wrappingemojiparser.go
+++ b/internal/tmpbbs/wrappingemojiparser.go
@@ -14,13 +14,6 @@ func newWrappingEmojiParser(wrapper *emojiSpanWrapper) *wrappingEmojiParser {
 	}
 }
 
-func (wep wrappingEmojiParser) parse(input string) string {
-	// This check shouldn't be necessary because it's checked for nil inside
-	// emoji.ParseWithWrapper but text/template complains about a nil pointer
-	// if it's not checked here.
-	if wep.wrapper == nil {
-		return emoji.Sprint(input)
-	}
-
+func (wep *wrappingEmojiParser) parse(input string) string {
 	return emoji.SprintWithWrapper(wep.wrapper, input)
 }


### PR DESCRIPTION
text/template no longer complains about this.

Give parse() a pointer receiver.